### PR TITLE
Change Discovery node type to Coordinator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.facebook.presto.csd</groupId>
   <artifactId>PRESTO</artifactId>
-  <version>0.3</version>
+  <version>0.4</version>
   <name>presto-csd</name>
 
   <build>

--- a/src/main/resources/descriptor/service.sdl
+++ b/src/main/resources/descriptor/service.sdl
@@ -556,7 +556,7 @@
             "additionalConfigs" : [
               {
                 "key" : "coordinator",
-                "value" : "false"
+                "value" : "true"
               },
               {
                 "key" : "discovery-server.enabled",


### PR DESCRIPTION
- Change Discovery node type to Coordinator (from Worker)
  - After Presto 0.209, Discovery service must be in Coordinator node
    - https://github.com/prestosql/presto/commit/c1287aa36c7a8c1c9db09bfe7f97e2d29f26e86d
